### PR TITLE
Removes Chemical Medipen and Adds Armor to Sec Biosuit

### DIFF
--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/medical.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/medical.yml
@@ -7,4 +7,3 @@
     EpinephrineChemistryBottle: 3
     Syringe: 3
     ClothingEyesGlasses: 5
-    ChemicalMedipen: 3

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/bio.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/bio.yml
@@ -73,6 +73,14 @@
     sprite: Clothing/OuterClothing/Bio/security.rsi
   - type: Clothing
     sprite: Clothing/OuterClothing/Bio/security.rsi
+  - type: Armor
+    modifiers:
+      coefficients:
+        Blunt: 0.9
+        Slash: 0.9
+        Piercing: 0.6
+        Heat: 0.9
+        Radiation: 0.8
   - type: Tag
     tags:
       - FullBodyOuter

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/bio.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/bio.yml
@@ -67,7 +67,7 @@
   id: ClothingOuterBioSecurity
   name: bio suit
   suffix: Security
-  description: A suit that protects against biological contamination, in Security colors.
+  description: A suit that protects against biological contamination and gunfire, in Security colors.
   components:
   - type: Sprite
     sprite: Clothing/OuterClothing/Bio/security.rsi


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

I've got 2 small changes. 
The first is to give the Sec Biosuit armor due to the sprite having armor. This makes sense due to sec needing some armor but shouldn't really cause everyone to use them all the time as there is still a slowdown from the suit. 
The second change is removing the Chemical Medipen from the Medical vendor, essentially from the entire game unless spawned in from admins. It was essentially a better Hypnopen that anyone could get with ease and abuse as a very strong weapon.

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- add: Added armor to Sec Biosuit
- remove: Removed Chemical Medipen

