### PR TITLE
Increase Reinforcement TC count from 12 to 13

### DIFF
--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -264,7 +264,7 @@
   productEntity: ReinforcementRadioSyndicate
   icon: { sprite: Objects/Devices/communication.rsi, state: old-radio }
   cost:
-    Telecrystal: 12
+    Telecrystal: 13
   categories:
   - UplinkUtility
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

# About the PR
<!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

If 2 Syndies have 16 TC (essentially the base), and kill Renault for 5TC, they can buy 3 agents which in all is not that difficult. As seen yesterday it was also obvious that with the right plays and a little luck you can easily control the entire station in about 5 minutes. 

13 TC would make it far more difficult for 2 Syndies to get 3 agents. Sure you can still go from 2 Syndies to 4 but it's more equal to the general firepower. This doesn't solve the probability problem that one of the 5 might go ham on everyone and everything but it makes it a bit more handle able. 

I'm open to increasing it even higher but 13 should work decently and still keep agent a possible buy. 


# Changelog
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl: BlitzGunner225
- tweak: Tweaked Syndicate reinforcement radio from 12 to 13
