### PR TITLE
Add node scanner to loadout

### DIFF
--- a/Resources/Prototypes/SimpleStation14/Loadouts/jobs.yml
+++ b/Resources/Prototypes/SimpleStation14/Loadouts/jobs.yml
@@ -399,6 +399,17 @@
     - Cataloguer
     - Scientist
   item: PinpointerArtifact
+  
+- type: loadout
+  id: LoadoutScienceItemNodeScanner
+  name: Node scanner
+  description: "A handheld scanner for checking which node an artifact is on."
+  category: Jobs
+  cost: 3
+  jobWhitelist:
+    - Epistemologist
+    - Scientist
+  item: NodeScanner
 
 
 # Service


### PR DESCRIPTION
# About the PR
The most useful tool in all of epistemics, now added to the loadout. Perhaps others will discover its' usefulness by doing this.

I did consider adding the anomaly scanner too, but those are often already available in the maps and I didn't want to overburden a simple pull request. It's up to the maintainers if that should get added.

# Changelog

:cl: Pixel
- add: Added node scanner to loadout
