### PR TITLE
Remove ghost role from mice

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -705,13 +705,13 @@
   id: MobMouse
   description: Squeak!
   components:
-  - type: GhostTakeoverAvailable
-    makeSentient: true
-    allowSpeech: true
-    allowMovement: true
-    whitelistRequired: false
-    name: ghost-role-information-mouse-name
-    description: ghost-role-information-mouse-description
+  # - type: GhostTakeoverAvailable
+  #   makeSentient: true
+  #   allowSpeech: true
+  #   allowMovement: true
+  #   whitelistRequired: false
+  #   name: ghost-role-information-mouse-name
+  #   description: ghost-role-information-mouse-description
   - type: Speech
     speechSounds: Squeak
   - type: Sprite


### PR DESCRIPTION
# Description
<!--
Describe the Pull Request here.
What does it change?
What other things could this impact?
-->
I hate mice.
Remove the ghost role from mice.
Mice were merely bloating the ghost role UI, providing nothing but a massive annoyance.
All the mice do is one of the following:
- Eat ***all the food*** (how the fuck can a single mouse eat more than an entire 30-person crew???)
- Eat all of the medicine
- Abuse the emote channel, spreading information through it, breaking rules (bypassing speech restrictions)

*Occasionally* there is an okay mouse player, but they add nothing of value to the round.

# Changelog
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.
There are 4 icons for changelog entries: add, remove, tweak, fix.

You can put your name after the :cl: symbol to change the name that shows in the changelog.
Like so:
:cl: PJB

Generally, only put things in changelogs that players actually care about.
Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl: DEATHB4DEFEAT
- remove: Nanotrasen has finally decided to do something about the mice problem, mice on the station are now guaranteed* to be stupid (remove mouse ghost role)
