### PR TITLE
Tweaked CSS and AI weights.

### DIFF
--- a/Resources/Prototypes/SimpleStation14/Roles/Jobs/Command/stationai.yml
+++ b/Resources/Prototypes/SimpleStation14/Roles/Jobs/Command/stationai.yml
@@ -5,6 +5,7 @@
   requirements:
     - !type:OverallPlaytimeRequirement
       time: 60000
+  weight: 30
   icon: "StationAI"
   supervisors: "all crew"
   accessGroups:

--- a/Resources/Prototypes/SimpleStation14/Roles/Jobs/Service/chief_service_supervisor.yml
+++ b/Resources/Prototypes/SimpleStation14/Roles/Jobs/Service/chief_service_supervisor.yml
@@ -8,7 +8,7 @@
       time: 3600
     - !type:OverallPlaytimeRequirement
       time: 54000
-  weight: 20
+  weight: 10
   startingGear: CSSGear
   icon: "ChiefServiceSupervisor"
   requireAdminNotify: true


### PR DESCRIPTION
# Description
CSS weight is now 10 (same as other Heads), and AI is now 30, to _really_ get them in. HoP remains 20, simply because the ability to promote other Heads is pretty good, but I am willing to discuss this as I am concerned it may lead to more Hoptains