### PR TITLE
[Job] Increase most job playtime requirements

### DIFF
--- a/Resources/Prototypes/Nyanotrasen/Roles/Jobs/Engineering/cyborg.yml
+++ b/Resources/Prototypes/Nyanotrasen/Roles/Jobs/Engineering/cyborg.yml
@@ -4,9 +4,6 @@
   description: job-description-cyborg
   playTimeTracker: JobCyborg
   requirements:
-    - !type:DepartmentTimeRequirement
-      department: Engineering
-      time: 14400
     - !type:OverallPlaytimeRequirement
       time: 28800
   icon: "Unknown"

--- a/Resources/Prototypes/Nyanotrasen/Roles/Jobs/Engineering/cyborg.yml
+++ b/Resources/Prototypes/Nyanotrasen/Roles/Jobs/Engineering/cyborg.yml
@@ -4,6 +4,9 @@
   description: job-description-cyborg
   playTimeTracker: JobCyborg
   requirements:
+    - !type:DepartmentTimeRequirement
+      department: Engineering
+      time: 14400
     - !type:OverallPlaytimeRequirement
       time: 28800
   icon: "Unknown"

--- a/Resources/Prototypes/Nyanotrasen/Roles/Jobs/Engineering/cyborg.yml
+++ b/Resources/Prototypes/Nyanotrasen/Roles/Jobs/Engineering/cyborg.yml
@@ -5,7 +5,7 @@
   playTimeTracker: JobCyborg
   requirements:
     - !type:OverallPlaytimeRequirement
-      time: 24000
+      time: 28800
   icon: "Unknown"
   supervisors: job-supervisors-human
   canBeAntag: false

--- a/Resources/Prototypes/Nyanotrasen/Roles/Jobs/Epistemics/mystagogue.yml
+++ b/Resources/Prototypes/Nyanotrasen/Roles/Jobs/Epistemics/mystagogue.yml
@@ -10,7 +10,7 @@
       department: Epistemics
       time: 18000
     - !type:OverallPlaytimeRequirement
-      time: 72000
+      time: 86400
   icon: "ResearchDirector"
   antagAdvantage: 6
   requireAdminNotify: true

--- a/Resources/Prototypes/Nyanotrasen/Roles/Jobs/Medical/medical_cyborg.yml
+++ b/Resources/Prototypes/Nyanotrasen/Roles/Jobs/Medical/medical_cyborg.yml
@@ -5,8 +5,11 @@
   playTimeTracker: JobCyborg
   whitelistRequired: true
   requirements:
+    - !type:DepartmentTimeRequirement
+      department: Medical
+      time: 14400
     - !type:OverallPlaytimeRequirement
-      time: 24000
+      time: 28800
   icon: "Unknown"
   supervisors: job-supervisors-human
   canBeAntag: false

--- a/Resources/Prototypes/Nyanotrasen/Roles/Jobs/Medical/paramedic.yml
+++ b/Resources/Prototypes/Nyanotrasen/Roles/Jobs/Medical/paramedic.yml
@@ -11,6 +11,8 @@
     - !type:DepartmentTimeRequirement
       department: Medical
       time: 14400
+    - !type:OverallPlaytimeRequirement
+      time: 21600
   access:
   - Medical
   - Maintenance

--- a/Resources/Prototypes/Nyanotrasen/Roles/Jobs/Security/prisonguard.yml
+++ b/Resources/Prototypes/Nyanotrasen/Roles/Jobs/Security/prisonguard.yml
@@ -4,12 +4,15 @@
   description: job-description-guard
   playTimeTracker: JobSecurityOfficer
   requirements:
+    - !type:DepartmentTimeRequirement
+      department: Security
+      time: 10800
     - !type:OverallPlaytimeRequirement
-      time: 18000
+      time: 36000
   startingGear: PrisonGuardGear
   alwaysUseSpawner: true
   canBeAntag: false
-  icon: "Warden" 
+  icon: "Warden"
   supervisors: job-supervisors-warden
   setPreference: true
   whitelistRequired: true

--- a/Resources/Prototypes/Roles/Jobs/Command/captain.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/captain.yml
@@ -6,13 +6,16 @@
   requirements:
     - !type:DepartmentTimeRequirement
       department: Engineering
-      time: 18000
+      time: 14400
     - !type:DepartmentTimeRequirement
       department: Medical
-      time: 18000
+      time: 14400
+    - !type:DepartmentTimeRequirement
+      department: Epistemics
+      time: 14400
     - !type:DepartmentTimeRequirement
       department: Security
-      time: 18000
+      time: 14400
     - !type:OverallPlaytimeRequirement
       time: 108000
   weight: 20

--- a/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
@@ -14,7 +14,7 @@
       department: Security
       time: 3600
     - !type:OverallPlaytimeRequirement
-      time: 54000
+      time: 93600
   weight: 20
   startingGear: HoPGear
   icon: "HeadOfPersonnel"

--- a/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
@@ -14,7 +14,7 @@
       department: Security
       time: 3600
     - !type:OverallPlaytimeRequirement
-      time: 93600
+      time: 86400
   weight: 20
   startingGear: HoPGear
   icon: "HeadOfPersonnel"

--- a/Resources/Prototypes/Roles/Jobs/Engineering/atmospheric_technician.yml
+++ b/Resources/Prototypes/Roles/Jobs/Engineering/atmospheric_technician.yml
@@ -6,7 +6,7 @@
   requirements:
     - !type:DepartmentTimeRequirement
       department: Engineering
-      time: 14400
+      time: 21600
   startingGear: AtmosphericTechnicianGear
   icon: "AtmosphericTechnician"
   supervisors: job-supervisors-ce

--- a/Resources/Prototypes/Roles/Jobs/Engineering/chief_engineer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Engineering/chief_engineer.yml
@@ -6,15 +6,15 @@
   requirements:
     - !type:RoleTimeRequirement
       role: JobAtmosphericTechnician
-      time: 7200
+      time: 21600
     - !type:RoleTimeRequirement
       role: JobSalvageTechnician
-      time: 3600
+      time: 7200
     - !type:DepartmentTimeRequirement
       department: Engineering
-      time: 18000
+      time: 28800
     - !type:OverallPlaytimeRequirement
-      time: 72000
+      time: 86400
   weight: 10
   startingGear: ChiefEngineerGear
   icon: "ChiefEngineer"

--- a/Resources/Prototypes/Roles/Jobs/Engineering/chief_engineer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Engineering/chief_engineer.yml
@@ -12,7 +12,7 @@
       time: 7200
     - !type:DepartmentTimeRequirement
       department: Engineering
-      time: 28800
+      time: 36000
     - !type:OverallPlaytimeRequirement
       time: 86400
   weight: 10

--- a/Resources/Prototypes/Roles/Jobs/Engineering/station_engineer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Engineering/station_engineer.yml
@@ -3,6 +3,9 @@
   name: job-name-engineer
   description: job-description-engineer
   playTimeTracker: JobStationEngineer
+  requirements:
+    - !type:OverallPlaytimeRequirement
+      time: 7200
   startingGear: StationEngineerGear
   icon: "StationEngineer"
   supervisors: job-supervisors-ce

--- a/Resources/Prototypes/Roles/Jobs/Medical/chemist.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/chemist.yml
@@ -6,7 +6,7 @@
   requirements:
     - !type:DepartmentTimeRequirement
       department: Medical
-      time: 1800
+      time: 7200
   startingGear: ChemistGear
   setPreference: false
   icon: "Chemist"

--- a/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
@@ -10,7 +10,7 @@
       department: Medical
       time: 18000
     - !type:OverallPlaytimeRequirement
-      time: 72000
+      time: 86400
   weight: 10
   startingGear: CMOGear
   icon: "ChiefMedicalOfficer"

--- a/Resources/Prototypes/Roles/Jobs/Science/research_director.yml
+++ b/Resources/Prototypes/Roles/Jobs/Science/research_director.yml
@@ -5,8 +5,11 @@
   setPreference: false
   playTimeTracker: JobResearchDirector
   requirements:
+    - !type:DepartmentTimeRequirement
+      department: Epistemics
+      time: 18000
     - !type:OverallPlaytimeRequirement
-      time: 108000
+      time: 86400
   weight: 10
   startingGear: ResearchDirectorGear
   icon: "ResearchDirector"

--- a/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
@@ -6,12 +6,12 @@
   requirements:
     - !type:RoleTimeRequirement
       role: JobWarden
-      time: 3600
+      time: 14400
     - !type:DepartmentTimeRequirement
       department: Security
-      time: 18000
+      time: 21600
     - !type:OverallPlaytimeRequirement
-      time: 54000
+      time: 93600
   weight: 10
   startingGear: HoSGear
   icon: "HeadOfSecurity"

--- a/Resources/Prototypes/Roles/Jobs/Security/security_officer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/security_officer.yml
@@ -4,8 +4,11 @@
   description: job-description-security
   playTimeTracker: JobSecurityOfficer
   requirements:
+    - !type:DepartmentTimeRequirement
+      department: Security
+      time: 3600
     - !type:OverallPlaytimeRequirement
-      time: 18000
+      time: 14400
   startingGear: SecurityOfficerGear
   icon: "SecurityOfficer"
   supervisors: job-supervisors-hos

--- a/Resources/Prototypes/Roles/Jobs/Security/warden.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/warden.yml
@@ -7,6 +7,8 @@
     - !type:DepartmentTimeRequirement
       department: Security
       time: 10800
+    - !type:OverallPlaytimeRequirement
+      time: 36000
   startingGear: WardenGear
   icon: "Warden"
   supervisors: job-supervisors-hos

--- a/Resources/Prototypes/Roles/Jobs/departments.yml
+++ b/Resources/Prototypes/Roles/Jobs/departments.yml
@@ -3,7 +3,7 @@
   description: department-Command-description
   color: "#334E6D"
   roles:
-  - SAI
+  - Captain
   - CentralCommandOfficial
   - ChiefServiceSupervisor
   - ChiefEngineer
@@ -15,8 +15,9 @@
   - ERTSecurity
   - HeadOfPersonnel
   - HeadOfSecurity
-  - ResearchDirector
   - Mystagogue
+  - ResearchDirector
+  - SAI
 
 - type: department
   id: Service

--- a/Resources/Prototypes/SimpleStation14/Roles/Jobs/Command/stationai.yml
+++ b/Resources/Prototypes/SimpleStation14/Roles/Jobs/Command/stationai.yml
@@ -4,8 +4,20 @@
   description: job-description-sai
   playTimeTracker: JobSAI
   requirements:
+    - !type:DepartmentTimeRequirement
+      department: Medical
+      time: 14400
+    - !type:DepartmentTimeRequirement
+      department: Epistemics
+      time: 14400
+    - !type:DepartmentTimeRequirement
+      department: Security
+      time: 14400
+    - !type:DepartmentTimeRequirement
+      department: Engineering
+      time: 14400
     - !type:OverallPlaytimeRequirement
-      time: 60000
+      time: 86400
   weight: 30
   icon: "StationAI"
   supervisors: "all crew"

--- a/Resources/Prototypes/SimpleStation14/Roles/Jobs/Command/stationai.yml
+++ b/Resources/Prototypes/SimpleStation14/Roles/Jobs/Command/stationai.yml
@@ -14,6 +14,9 @@
       department: Security
       time: 14400
     - !type:DepartmentTimeRequirement
+      department: Service
+      time: 14400
+    - !type:DepartmentTimeRequirement
       department: Engineering
       time: 14400
     - !type:OverallPlaytimeRequirement

--- a/Resources/Prototypes/SimpleStation14/Roles/Jobs/Service/chief_service_supervisor.yml
+++ b/Resources/Prototypes/SimpleStation14/Roles/Jobs/Service/chief_service_supervisor.yml
@@ -6,9 +6,9 @@
   requirements:
     - !type:DepartmentTimeRequirement
       department: Service
-      time: 3600
+      time: 21600
     - !type:OverallPlaytimeRequirement
-      time: 54000
+      time: 86400
   weight: 10
   startingGear: CSSGear
   icon: "ChiefServiceSupervisor"


### PR DESCRIPTION
# Description
<!--
Describe the Pull Request here.
What does it change?
What other things could this impact?
-->
Job playtimes were all *really* low, some stupidly low.
The most notable changes:
- All heads require 24h+ playtime (reflecting the whitelist requirement I have)
- Station AI requires 4 hours of playtime in all departments
- Borgs require time in their department
- Engineer requires 2 hours of overall playtime

<details><summary>Full Change list (times in hours)</summary>
<p>

## Command

- Station AI
    - Medical: **0** -> **4**
    - Epistemics: **0** -> **4**
    - Security: **0** -> **4**
    - Service: **0** -> **4**
    - Engineering: **0** -> **4**
    - Overall: **16.66...** -> **24**
- Captain
    - Engineering: **5** -> **4**
    - Medical: **5** -> **4**
    - Epistemics: **0** -> **4**
    - Security: **5** -> **4**
- Head of Personnel
    - Overall: **15** -> **24**

## Engineering

- Chief Engineer
    - Atmospheric Technician: **2** -> **6**
    - Salvage Technician: **1** -> **2**
    - Engineering: **5** -> **10**
    - Overall: **20** -> **24**
- Atmospheric Technician
    - Engineering: **4** -> **6**
- Station Engineer
    - Overall: **0** -> **2**
- Robot
    - Overall: **6.66...** -> **8**

## Epistemics

- Mystagogue
    - Overall: **20** -> **24**
- Research Director
    - Epistemics: **0** -> **5**
    - Overall: **30** -> **24**

## Medical

- Chief Medical Officer
    - Overall: **20** -> **24**
- Paramedic
    - Overall: **0** -> **6**
- Medical Robot
    - Medical: **0** -> **4**
    - Overall: **6.66...** -> **8**
- Chemist
    - Medical: **0.5** -> **2**

## Security

- Head of Security
    - Warden: **1** -> **4**
    - Security: **5** -> **6**
    - Overall: **15** -> **26**
- Prison Guard
    - Security: **0** -> **3**
    - Overall: **5** -> **10**
- Warden
    - Overall: **0** -> **10**
- Security Officer
    - Security: **0** -> **1**
    - Overall: **5** -> **4**


## Service

- Chief Service Supervisor
    - Service: **0.722...** -> **6**
    - Overall: **15** -> **24**

</p>
</details> 

# Changelog
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.
There are 4 icons for changelog entries: add, remove, tweak, fix.

You can put your name after the :cl: symbol to change the name that shows in the changelog.
Like so:
:cl: PJB

Generally, only put things in changelogs that players actually care about.
Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- tweak: Increased most job playtime requirements.