### PR TITLE
Give chemipens a large use delay

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/hypospray.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/hypospray.yml
@@ -88,6 +88,8 @@
     solution: pen
   - type: RefillableSolution
     solution: pen
+  - type: UseDelay
+    delay: 120 # Reusable but slow
 
 - type: entity
   name: emergency medipen
@@ -157,6 +159,8 @@
             Quantity: 20
   - type: Tag
     tags: []
+  - type: UseDelay
+    delay: 160 # Slower due to larger volume
 
 - type: entity
   name: stimulant injector
@@ -181,6 +185,8 @@
     price: 500
   - type: Tag
     tags: []
+  - type: UseDelay
+    delay: 240 # Very slow due to large volume
 
 - type: entity
   name: stimulant microinjector
@@ -226,6 +232,8 @@
     price: 1000
   - type: Tag
     tags: []
+  - type: UseDelay
+    delay: 240 # Very slow due to large volume
 
 - type: entity
   name: magic medipen
@@ -248,6 +256,8 @@
     reagents:
       - Ichor
     unitsPerSecond: 0.1
+  - type: UseDelay
+    delay: 5
 
 - type: entity
   name: pen


### PR DESCRIPTION
# Description
<!--
Describe the Pull Request here.
What does it change?
What other things could this impact?
-->
add big delay so they aren't just a great alternative to the hypospray

# Changelog
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.
There are 4 icons for changelog entries: add, remove, tweak, fix.

You can put your name after the :cl: symbol to change the name that shows in the changelog.
Like so:
:cl: PJB

Generally, only put things in changelogs that players actually care about.
Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- tweak: Chemical medipens (and all other forms of it) have a large reuse delay depending on their volume.
