### PR TITLE
Brief command uses Spawn perms

### DIFF
--- a/Content.Server/SimpleStation14/Administration/Commands/BriefCommand.cs
+++ b/Content.Server/SimpleStation14/Administration/Commands/BriefCommand.cs
@@ -11,7 +11,7 @@ using Robust.Shared.Prototypes;
 
 namespace Content.Server.Administration.Commands.Brief
 {
-    [AdminCommand(AdminFlags.Admin)]
+    [AdminCommand(AdminFlags.Spawn)]
     public sealed class BriefCommand : IConsoleCommand
     {
         [Dependency] private readonly IEntityManager _entities = default!;


### PR DESCRIPTION
# Description
Sets the Brief command to require Spawning perms
