### PR TITLE
Prescription Security glasses

### DIFF
--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/sec.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/sec.yml
@@ -7,7 +7,6 @@
     Flash: 5
     FlashlightSeclite: 5
     ClothingEyesGlassesSecurity: 4
-    ClothingEyesGlassesSecurityPrescription: 2
     ClothingBeltSecurityWebbing: 5
     Zipties: 12
     RiotShield: 2
@@ -16,6 +15,7 @@
     ClothingHeadHelmetInsulated: 2
     ClothingHeadCage: 2
     HyperlinkBookSpaceLaw: 2
+    ClothingEyesGlassesSecurityPrescription: 2
   # security officers need to follow a diet regimen!
   contrabandInventory:
     FoodDonutHomer: 12

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/sec.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/sec.yml
@@ -7,6 +7,7 @@
     Flash: 5
     FlashlightSeclite: 5
     ClothingEyesGlassesSecurity: 4
+    ClothingEyesGlassesSecurityPrescription: 2
     ClothingBeltSecurityWebbing: 5
     Zipties: 12
     RiotShield: 2

--- a/Resources/Prototypes/SimpleStation14/Entities/Clothing/Eyes/glasses.yml
+++ b/Resources/Prototypes/SimpleStation14/Entities/Clothing/Eyes/glasses.yml
@@ -1,18 +1,11 @@
 - type: entity
-  parent: ClothingEyesBase
+  parent: ClothingEyesGlassesSecurity
   id: ClothingEyesGlassesSecurityPrescription
   name: prescription security sunglasses
   description: Someone decided to mix the prescription and tinted lenses. Why hasn't this been thought of sooner?
   components:
-  - type: Sprite
-    sprite: Clothing/Eyes/Glasses/secglasses.rsi
-  - type: Clothing
-    sprite: Clothing/Eyes/Glasses/secglasses.rsi
   - type: VisionCorrection
   - type: ClothingGrantTag
     tag: GlassesNearsight
-  - type: FlashImmunity
-  - type: EyeProtection
-    protectionTime: 5
   - type: DropOnSlip
     chance: 5

--- a/Resources/Prototypes/SimpleStation14/Entities/Clothing/Eyes/glasses.yml
+++ b/Resources/Prototypes/SimpleStation14/Entities/Clothing/Eyes/glasses.yml
@@ -1,0 +1,18 @@
+- type: entity
+  parent: ClothingEyesBase
+  id: ClothingEyesGlassesSecurityPrescription
+  name: prescription security sunglasses
+  description: Someone decided to mix the prescription and tinted lenses. Why hasn't this been thought of sooner?
+  components:
+  - type: Sprite
+    sprite: Clothing/Eyes/Glasses/secglasses.rsi
+  - type: Clothing
+    sprite: Clothing/Eyes/Glasses/secglasses.rsi
+  - type: VisionCorrection
+  - type: ClothingGrantTag
+    tag: GlassesNearsight
+  - type: FlashImmunity
+  - type: EyeProtection
+    protectionTime: 5
+  - type: DropOnSlip
+    chance: 5

--- a/Resources/Prototypes/SimpleStation14/Entities/Clothing/Eyes/glasses.yml
+++ b/Resources/Prototypes/SimpleStation14/Entities/Clothing/Eyes/glasses.yml
@@ -9,3 +9,4 @@
     tag: GlassesNearsight
   - type: DropOnSlip
     chance: 5
+    

--- a/Resources/Prototypes/SimpleStation14/Loadouts/traits.yml
+++ b/Resources/Prototypes/SimpleStation14/Loadouts/traits.yml
@@ -32,10 +32,10 @@
   category: Traits
   cost: 4
   jobWhitelist:
+    - HeadOfSecurity
     - SecurityCadet
     - SecurityOfficer
     - Warden
-    - HeadOfSecurity
   whitelist:
     components:
       - Nearsighted

--- a/Resources/Prototypes/SimpleStation14/Loadouts/traits.yml
+++ b/Resources/Prototypes/SimpleStation14/Loadouts/traits.yml
@@ -24,3 +24,19 @@
     components:
       - Nearsighted
   item: ClothingEyesHudMedicalPrescription
+
+- type: loadout
+  id: LoadoutNearsightedEyesSecurityGlasses
+  name: Prescription Security Glasses
+  description: Now you can see AND be stylish!
+  category: Traits
+  cost: 4
+  jobWhitelist:
+    - SecurityCadet
+    - SecurityOfficer
+    - Warden
+    - HeadOfSecurity
+  whitelist:
+    components:
+      - Nearsighted
+  item: ClothingEyesGlassesSecurityPrescription


### PR DESCRIPTION
The old PR broke so I redid it.

# Description

Adds prescription security glasses
they have a small chance to fall off your face when you slip. Small enough that it wont be a problem normally but just enough so that it'll be noticeable

Adds 2 units to SecTech
Adds to loadouts for 4 points

# Media
![image](https://github.com/Park-Station/Parkstation/assets/130223709/20294b62-9bb8-4efa-ba06-2deba8202eb7)