### PR TITLE
GunComponents will now roll to fire accidentally when dropped.

### DIFF
--- a/Content.Server/SimpleStation14/Weapons/Ranged/Systems/FireOnDropSystem.cs
+++ b/Content.Server/SimpleStation14/Weapons/Ranged/Systems/FireOnDropSystem.cs
@@ -15,10 +15,10 @@ public sealed class FireOnDropSystem : EntitySystem
     {
         base.Initialize();
 
-        SubscribeLocalEvent<GunComponent, LandEvent>(HandleEmitSoundOnDrop);
+        SubscribeLocalEvent<GunComponent, LandEvent>(HandleLand);
     }
 
-    private void HandleEmitSoundOnDrop(EntityUid uid, GunComponent component, ref LandEvent args)
+    private void HandleLand(EntityUid uid, GunComponent component, ref LandEvent args)
     {
         var physicsComp = EntityManager.GetComponent<PhysicsComponent>(uid);
 

--- a/Content.Server/SimpleStation14/Weapons/Ranged/Systems/FireOnDropSystem.cs
+++ b/Content.Server/SimpleStation14/Weapons/Ranged/Systems/FireOnDropSystem.cs
@@ -1,0 +1,33 @@
+using Content.Shared.Throwing;
+using Content.Shared.Weapons.Ranged.Components;
+using Content.Shared.Weapons.Ranged.Systems;
+using Robust.Shared.Physics.Components;
+using Robust.Shared.Random;
+
+namespace Content.Server.SimpleStation14.Weapons.Ranged.Systems;
+
+public sealed class FireOnDropSystem : EntitySystem
+{
+    [Dependency] private readonly SharedGunSystem _gun = default!;
+    [Dependency] private readonly IRobustRandom _random = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<GunComponent, LandEvent>(HandleEmitSoundOnDrop);
+    }
+
+    private void HandleEmitSoundOnDrop(EntityUid uid, GunComponent component, ref LandEvent args)
+    {
+        var physicsComp = EntityManager.GetComponent<PhysicsComponent>(uid);
+
+        // TODO: This shouldn't be a hardcoded 10% roll. I wanted to base it off mass, but items don't seem
+        // to care about their mass (most guns had the same.).
+        // Then I wanted to base it off of item size, but the minigun still has a size of 5 at the time of writing, so :shrug:
+        if (_random.Prob(0.1f))
+            _gun.AttemptShoot(uid, uid, component, Transform(uid).Coordinates.Offset(Transform(uid).LocalRotation.ToVec()));
+        // The gun fires itself (weird), with the target being its own position offset by its rotation as a point vector.
+        // The result being that it will always fire the direction that all gun sprites point in.
+    }
+}


### PR DESCRIPTION
# Description
GunComponents will now roll to fire accidentally when dropped.

:cl:
- add: Nanotrasen have disabled the unneeded safeties on your guns- Make sure you're carful with them!
