### PR TITLE
Robot role allotment fix

### DIFF
--- a/Resources/Prototypes/Maps/parkstation.yml
+++ b/Resources/Prototypes/Maps/parkstation.yml
@@ -1,4 +1,4 @@
-﻿- type: gameMap
+- type: gameMap
   id: ParkStation
   mapName: 'ParkStation'
   mapPath: /Maps/parkstation.yml
@@ -21,7 +21,7 @@
         Boxer: [ 1, 2 ]
         Chef: [ 1, 1 ]
         Clown: [ 1, 1 ]
-        Cyborg: [ 2, 2 ]
+        Robot: [ 2, 2 ]
         Janitor: [ 2, 3 ]
         Mime: [ 1, 1 ]
         HeadOfPersonnel: [ 1, 1 ]
@@ -30,7 +30,7 @@
         ChiefMedicalOfficer: [ 1, 1 ]
         MailCarrier: [ 1, 2 ]
         MedicalDoctor: [ 3, 6 ]
-        MedicalCyborg: [ 1, 2 ]
+        MedicalRobot: [ 1, 2 ]
         Mystagogue: [ 1, 1 ]
         Epistemologist: [ 2, 5 ]
         HeadOfSecurity: [ 1, 1 ]


### PR DESCRIPTION

# Description
Changes the borg role identifier/quantifier in the parkstation map yaml to Robot and MedicalRobot from Cyborg and MedicalCyborg, allowing the jobs to properly be spawned.

:cl: SomeCabbage
- fix: Nanotrasen fixed up a typo in their paperwork, meaning robots (cyborgs) can once again be present on station!