### PR TITLE
Bolt Signals for Airlocks

### DIFF
--- a/Content.Server/Doors/Systems/AirlockSystem.cs
+++ b/Content.Server/Doors/Systems/AirlockSystem.cs
@@ -50,6 +50,20 @@ namespace Content.Server.Doors.Systems
             {
                 component.AutoClose = false;
             }
+            // Parkstation-BoltSignal-Start
+            else if (args.Port == component.BoltPort)
+            {
+                SetBoltsWithAudio(uid, component, true);
+            }
+            else if (args.Port == component.UnBoltPort)
+            {
+                SetBoltsWithAudio(uid, component, false);
+            }
+            else if (args.Port == component.ToggleBoltPort)
+            {
+                SetBoltsWithAudio(uid, component, !component.BoltsDown);
+            }
+            // Parkstation-BoltSignal-End
         }
 
         private void OnPowerChanged(EntityUid uid, AirlockComponent component, ref PowerChangedEvent args)

--- a/Content.Shared/Doors/Components/AirlockComponent.cs
+++ b/Content.Shared/Doors/Components/AirlockComponent.cs
@@ -98,6 +98,26 @@ public sealed class AirlockComponent : Component
     [DataField("autoClosePort", customTypeSerializer: typeof(PrototypeIdSerializer<ReceiverPortPrototype>))]
     public string AutoClosePort = "AutoClose";
 
+    // Parkstation-BoltSignal-Start
+    /// <summary>
+    /// The receiver port for bolting the airlock.
+    /// </summary>
+    [DataField("boltPort", customTypeSerializer: typeof(PrototypeIdSerializer<ReceiverPortPrototype>))]
+    public string BoltPort = "Bolt";
+
+    /// <summary>
+    /// The receiver port for unbolt the airlock.
+    /// </summary>
+    [DataField("unBoltPort", customTypeSerializer: typeof(PrototypeIdSerializer<ReceiverPortPrototype>))]
+    public string UnBoltPort = "UnBolt";
+
+    /// <summary>
+    /// The receiver port for toggling the bolt state of the airlock.
+    /// </summary>
+    [DataField("toggleBoltPort", customTypeSerializer: typeof(PrototypeIdSerializer<ReceiverPortPrototype>))]
+    public string ToggleBoltPort = "ToggleBolt";
+    // Parkstation-BoltSignal-End
+
     #region Graphics
 
     /// <summary>

--- a/Resources/Locale/en-US/machine-linking/receiver_ports.ftl
+++ b/Resources/Locale/en-US/machine-linking/receiver_ports.ftl
@@ -54,3 +54,13 @@ signal-port-description-artifact-analyzer-sender = Analysis console signal sende
 
 signal-port-name-artifact-analyzer-receiver = Pad
 signal-port-description-artifact-analyzer-receiver = Artifact analyzer signal receiver
+
+## Parkstation
+signal-port-name-bolt = Bolt
+signal-port-description-bolt = Bolts the door.
+
+signal-port-name-unbolt = Unbolt
+signal-port-description-unbolt = Unbolts the door.
+
+signal-port-name-togglebolt = Toggle bolt
+signal-port-description-togglebolt = Toggles the bolt state of the door.

--- a/Resources/Prototypes/Entities/Structures/Doors/Airlocks/base_structureairlocks.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Airlocks/base_structureairlocks.yml
@@ -83,6 +83,9 @@
       Close: []
       Toggle: []
       AutoClose: []
+      Bolt: []
+      UnBolt: []
+      ToggleBolt: []
   - type: UserInterface
     interfaces:
     - key: enum.WiresUiKey.Key

--- a/Resources/Prototypes/SimpleStation14/MachineLinking/receiver_ports.yml
+++ b/Resources/Prototypes/SimpleStation14/MachineLinking/receiver_ports.yml
@@ -1,0 +1,14 @@
+- type: receiverPort
+  id: Bolt
+  name: signal-port-name-bolt
+  description: signal-port-description-bolt
+
+- type: receiverPort
+  id: UnBolt
+  name: signal-port-name-unbolt
+  description: signal-port-description-unbolt
+
+- type: receiverPort
+  id: ToggleBolt
+  name: signal-port-name-togglebolt
+  description: signal-port-description-togglebolt


### PR DESCRIPTION
# Description
Adds bolt signals to airlocks, mostly for use with Brig timers.
How was this not done before?


# Changelog

:cl:
- add: Airlocks now have various Bolt signal ports.
