### PR TITLE
Shadowkin fixes (real)

### DIFF
--- a/Content.Server/SimpleStation14/Species/Shadowkin/Systems/ShadowkinPowerSystem.DarkSwap.cs
+++ b/Content.Server/SimpleStation14/Species/Shadowkin/Systems/ShadowkinPowerSystem.DarkSwap.cs
@@ -6,6 +6,7 @@ using Content.Server.Visible;
 using Content.Shared.Actions;
 using Content.Shared.Actions.ActionTypes;
 using Content.Shared.CombatMode.Pacification;
+using Content.Shared.Cuffs.Components;
 using Content.Shared.Damage.Systems;
 using Content.Shared.SimpleStation14.Species.Shadowkin.Components;
 using Content.Shared.SimpleStation14.Species.Shadowkin.Events;
@@ -57,6 +58,16 @@ public sealed class ShadowkinDarkSwapSystem : EntitySystem
 
     private void DarkSwap(EntityUid uid, ShadowkinDarkSwapPowerComponent component, ShadowkinDarkSwapEvent args)
     {
+        // Need power to drain power
+        if (!_entity.HasComponent<ShadowkinComponent>(args.Performer))
+            return;
+
+        // Don't activate abilities if handcuffed
+        // TODO: Something like the Psionic Headcage to disable powers for Shadowkin
+        if (_entity.HasComponent<HandcuffComponent>(args.Performer))
+            return;
+
+
         var hasComp = _entity.HasComponent<ShadowkinDarkSwappedComponent>(args.Performer);
 
         SetDarkened(

--- a/Content.Server/SimpleStation14/Species/Shadowkin/Systems/ShadowkinPowerSystem.DarkSwap.cs
+++ b/Content.Server/SimpleStation14/Species/Shadowkin/Systems/ShadowkinPowerSystem.DarkSwap.cs
@@ -30,13 +30,9 @@ public sealed class ShadowkinDarkSwapSystem : EntitySystem
     [Dependency] private readonly IPrototypeManager _prototype = default!;
     [Dependency] private readonly MagicSystem _magic = default!;
 
-    private InstantAction _action = default!;
-
     public override void Initialize()
     {
         base.Initialize();
-
-        _action = new InstantAction(_prototype.Index<InstantActionPrototype>("ShadowkinDarkSwap"));
 
         SubscribeLocalEvent<ShadowkinDarkSwapPowerComponent, ComponentStartup>(Startup);
         SubscribeLocalEvent<ShadowkinDarkSwapPowerComponent, ComponentShutdown>(Shutdown);
@@ -50,12 +46,12 @@ public sealed class ShadowkinDarkSwapSystem : EntitySystem
 
     private void Startup(EntityUid uid, ShadowkinDarkSwapPowerComponent component, ComponentStartup args)
     {
-        _actions.AddAction(uid, _action, uid);
+        _actions.AddAction(uid, new InstantAction(_prototype.Index<InstantActionPrototype>("ShadowkinDarkSwap")), null);
     }
 
     private void Shutdown(EntityUid uid, ShadowkinDarkSwapPowerComponent component, ComponentShutdown args)
     {
-        _actions.RemoveAction(uid, _action);
+        _actions.RemoveAction(uid, new InstantAction(_prototype.Index<InstantActionPrototype>("ShadowkinDarkSwap")));
     }
 
 

--- a/Content.Server/SimpleStation14/Species/Shadowkin/Systems/ShadowkinPowerSystem.Darken.cs
+++ b/Content.Server/SimpleStation14/Species/Shadowkin/Systems/ShadowkinPowerSystem.Darken.cs
@@ -78,7 +78,7 @@ public sealed class ShadowkinDarkenSystem : EntitySystem
                 if (!_entity.TryGetComponent(light, out ShadowkinLightComponent? shadowkinLight))
                     continue;
                 // Not powered, undo changes
-                if (!_entity.TryGetComponent(light, out PoweredLightComponent? powered) || !powered.On)
+                if (_entity.TryGetComponent(light, out PoweredLightComponent? powered) && !powered.On)
                 {
                     ResetLight(pointLight, shadowkinLight);
                     continue;
@@ -98,10 +98,10 @@ public sealed class ShadowkinDarkenSystem : EntitySystem
                     shadowkin.DarkenedLights.Remove(light);
                     continue;
                 }
-                // 10% chance to remove the attached entity so it can become another Shadowkin's light
+                // 3% chance to remove the attached entity so it can become another Shadowkin's light
                 if (shadowkinLight.AttachedEntity == uid)
                 {
-                    if (_random.Prob(0.1f))
+                    if (_random.Prob(0.03f))
                         shadowkinLight.AttachedEntity = EntityUid.Invalid;
                 }
 

--- a/Content.Server/SimpleStation14/Species/Shadowkin/Systems/ShadowkinPowerSystem.Rest.cs
+++ b/Content.Server/SimpleStation14/Species/Shadowkin/Systems/ShadowkinPowerSystem.Rest.cs
@@ -3,6 +3,7 @@ using Content.Server.SimpleStation14.Species.Shadowkin.Events;
 using Content.Shared.Actions;
 using Content.Shared.Actions.ActionTypes;
 using Content.Shared.Bed.Sleep;
+using Content.Shared.Cuffs.Components;
 using Content.Shared.SimpleStation14.Species.Shadowkin.Components;
 using Robust.Shared.Prototypes;
 
@@ -38,8 +39,15 @@ public sealed class ShadowkinRestSystem : EntitySystem
 
     private void Rest(EntityUid uid, ShadowkinRestPowerComponent component, ShadowkinRestEvent args)
     {
+        // Need power to modify power
         if (!_entity.HasComponent<ShadowkinComponent>(args.Performer))
             return;
+
+        // Rest is a funny ability, keep it :)
+        // // Don't activate abilities if handcuffed
+        // if (_entity.HasComponent<HandcuffComponent>(args.Performer))
+        //     return;
+
 
         // Now doing what you weren't before
         component.IsResting = !component.IsResting;

--- a/Content.Server/SimpleStation14/Species/Shadowkin/Systems/ShadowkinPowerSystem.Rest.cs
+++ b/Content.Server/SimpleStation14/Species/Shadowkin/Systems/ShadowkinPowerSystem.Rest.cs
@@ -15,13 +15,9 @@ public sealed class ShadowkinRestSystem : EntitySystem
     [Dependency] private readonly SharedActionsSystem _actions = default!;
     [Dependency] private readonly ShadowkinPowerSystem _power = default!;
 
-    private InstantAction _action = default!;
-
     public override void Initialize()
     {
         base.Initialize();
-
-        _action = new InstantAction(_prototype.Index<InstantActionPrototype>("ShadowkinRest"));
 
         SubscribeLocalEvent<ShadowkinRestPowerComponent, ComponentStartup>(OnStartup);
         SubscribeLocalEvent<ShadowkinRestPowerComponent, ComponentShutdown>(OnShutdown);
@@ -32,12 +28,12 @@ public sealed class ShadowkinRestSystem : EntitySystem
 
     private void OnStartup(EntityUid uid, ShadowkinRestPowerComponent component, ComponentStartup args)
     {
-        _actions.AddAction(uid, _action, uid);
+        _actions.AddAction(uid, new InstantAction(_prototype.Index<InstantActionPrototype>("ShadowkinRest")), null);
     }
 
     private void OnShutdown(EntityUid uid, ShadowkinRestPowerComponent component, ComponentShutdown args)
     {
-        _actions.RemoveAction(uid, _action);
+        _actions.RemoveAction(uid, new InstantAction(_prototype.Index<InstantActionPrototype>("ShadowkinRest")));
     }
 
     private void Rest(EntityUid uid, ShadowkinRestPowerComponent component, ShadowkinRestEvent args)

--- a/Content.Server/SimpleStation14/Species/Shadowkin/Systems/ShadowkinPowerSystem.Teleport.cs
+++ b/Content.Server/SimpleStation14/Species/Shadowkin/Systems/ShadowkinPowerSystem.Teleport.cs
@@ -24,13 +24,9 @@ public sealed class ShadowkinTeleportSystem : EntitySystem
     [Dependency] private readonly IPrototypeManager _prototype = default!;
     [Dependency] private readonly MagicSystem _magic = default!;
 
-    private WorldTargetAction _action = default!;
-
     public override void Initialize()
     {
         base.Initialize();
-
-        _action = new WorldTargetAction(_prototype.Index<WorldTargetActionPrototype>("ShadowkinTeleport"));
 
         SubscribeLocalEvent<ShadowkinTeleportPowerComponent, ComponentStartup>(Startup);
         SubscribeLocalEvent<ShadowkinTeleportPowerComponent, ComponentShutdown>(Shutdown);
@@ -41,12 +37,12 @@ public sealed class ShadowkinTeleportSystem : EntitySystem
 
     private void Startup(EntityUid uid, ShadowkinTeleportPowerComponent component, ComponentStartup args)
     {
-        _actions.AddAction(uid, _action, uid);
+        _actions.AddAction(uid, new WorldTargetAction(_prototype.Index<WorldTargetActionPrototype>("ShadowkinTeleport")), null);
     }
 
     private void Shutdown(EntityUid uid, ShadowkinTeleportPowerComponent component, ComponentShutdown args)
     {
-        _actions.RemoveAction(uid, _action);
+        _actions.RemoveAction(uid, new WorldTargetAction(_prototype.Index<WorldTargetActionPrototype>("ShadowkinTeleport")));
     }
 
 

--- a/Content.Server/SimpleStation14/Species/Shadowkin/Systems/ShadowkinPowerSystem.Teleport.cs
+++ b/Content.Server/SimpleStation14/Species/Shadowkin/Systems/ShadowkinPowerSystem.Teleport.cs
@@ -4,6 +4,7 @@ using Content.Server.SimpleStation14.Species.Shadowkin.Components;
 using Content.Server.SimpleStation14.Species.Shadowkin.Events;
 using Content.Shared.Actions;
 using Content.Shared.Actions.ActionTypes;
+using Content.Shared.Cuffs.Components;
 using Content.Shared.Damage.Systems;
 using Content.Shared.Pulling.Components;
 using Content.Shared.SimpleStation14.Species.Shadowkin.Components;
@@ -48,8 +49,13 @@ public sealed class ShadowkinTeleportSystem : EntitySystem
 
     private void Teleport(EntityUid uid, ShadowkinTeleportPowerComponent component, ShadowkinTeleportEvent args)
     {
-        if (args.Handled ||
-            !_entity.TryGetComponent<ShadowkinComponent>(args.Performer, out var comp))
+        // Need power to drain power
+        if (!_entity.TryGetComponent<ShadowkinComponent>(args.Performer, out var comp))
+            return;
+
+        // Don't activate abilities if handcuffed
+        // TODO: Something like the Psionic Headcage to disable powers for Shadowkin
+        if (_entity.HasComponent<HandcuffComponent>(args.Performer))
             return;
 
 

--- a/Content.Server/SimpleStation14/Species/Shadowkin/Systems/ShadowkinSystem.cs
+++ b/Content.Server/SimpleStation14/Species/Shadowkin/Systems/ShadowkinSystem.cs
@@ -89,14 +89,21 @@ public sealed class ShadowkinSystem : EntitySystem
         // Update power level for all shadowkin
         while (query.MoveNext(out var uid, out var shadowkin))
         {
-            // Skip if the shadowkin is dead or catatonic
+            // Ensure dead or critical shadowkin aren't swapped, skip them
             if (_mobState.IsDead(uid) ||
-                !_entity.System<MindSystem>().TryGetMind(uid, out var mind) ||
+                _mobState.IsCritical(uid))
+            {
+                _entity.RemoveComponent<ShadowkinDarkSwappedComponent>(uid);
+                continue;
+            }
+
+            // Don't update things for ssd shadowkin
+            if (!_entity.System<MindSystem>().TryGetMind(uid, out var mind) ||
                 mind.Session == null)
                 continue;
 
-            var oldPowerLevel = _power.GetLevelName(shadowkin.PowerLevel);
 
+            var oldPowerLevel = _power.GetLevelName(shadowkin.PowerLevel);
             _power.TryUpdatePowerLevel(uid, frameTime);
 
             if (oldPowerLevel != _power.GetLevelName(shadowkin.PowerLevel))

--- a/Content.Server/SimpleStation14/Species/Shadowkin/Systems/ShadowkinSystem.cs
+++ b/Content.Server/SimpleStation14/Species/Shadowkin/Systems/ShadowkinSystem.cs
@@ -2,6 +2,7 @@ using System.Numerics;
 using Content.Server.Mind;
 using Content.Server.Mind.Components;
 using Content.Server.SimpleStation14.Species.Shadowkin.Events;
+using Content.Shared.Cuffs.Components;
 using Content.Shared.Examine;
 using Content.Shared.IdentityManagement;
 using Content.Shared.Interaction;
@@ -113,6 +114,12 @@ public sealed class ShadowkinSystem : EntitySystem
             }
             // I can't figure out how to get this to go to the 100% filled state in the above if statement 😢
             _power.UpdateAlert(uid, true, shadowkin.PowerLevel);
+
+
+            // Don't randomly activate abilities if handcuffed
+            // TODO: Something like the Psionic Headcage to disable powers for Shadowkin
+            if (_entity.HasComponent<HandcuffComponent>(uid))
+                continue;
 
             #region MaxPower
             // Check if they're at max power

--- a/Content.Server/SimpleStation14/Species/Shadowkin/Systems/ShadowkinSystem.cs
+++ b/Content.Server/SimpleStation14/Species/Shadowkin/Systems/ShadowkinSystem.cs
@@ -2,6 +2,7 @@ using System.Numerics;
 using Content.Server.Mind;
 using Content.Server.Mind.Components;
 using Content.Server.SimpleStation14.Species.Shadowkin.Events;
+using Content.Shared.Bed.Sleep;
 using Content.Shared.Cuffs.Components;
 using Content.Shared.Examine;
 using Content.Shared.IdentityManagement;
@@ -163,7 +164,9 @@ public sealed class ShadowkinSystem : EntitySystem
                 (
                     ShadowkinComponent.PowerThresholds[ShadowkinPowerThreshold.Tired] +
                     ShadowkinComponent.PowerThresholds[ShadowkinPowerThreshold.Okay]
-                ) / 2f
+                ) / 2f &&
+                // Don't sleep if asleep
+                !_entity.HasComponent<SleepingComponent>(uid)
             )
             {
                 // If so, start the timer

--- a/Resources/Prototypes/Entities/Objects/Devices/pda.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/pda.yml
@@ -57,6 +57,7 @@
       icon: { sprite: Objects/Tools/flashlight.rsi, state: flashlight }
       iconOn: Objects/Tools/flashlight.rsi/flashlight-on.png
       event: !type:ToggleActionEvent
+  - type: ShadowkinLight
   - type: PointLight
     enabled: false
     radius: 1.5

--- a/Resources/Prototypes/Entities/Objects/Misc/fluff_lights.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/fluff_lights.yml
@@ -45,6 +45,7 @@
     sprite: Objects/Misc/Lights/lights.rsi
     size: 20
     heldPrefix: off
+  - type: ShadowkinLight
   - type: PointLight
     enabled: false
     radius: 3

--- a/Resources/Prototypes/Entities/Objects/Tools/flashlights.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/flashlights.yml
@@ -69,6 +69,7 @@
         map: [ "light" ]
   - type: Item
     sprite: Objects/Tools/flashlight.rsi
+  - type: ShadowkinLight
   - type: PointLight
     enabled: false
     mask: /Textures/Effects/LightMasks/cone.png

--- a/Resources/Prototypes/Entities/Structures/Lighting/base_lighting.yml
+++ b/Resources/Prototypes/Entities/Structures/Lighting/base_lighting.yml
@@ -29,6 +29,7 @@
     - state: on
       map: ["enum.PoweredLightLayers.Base"]
     state: on
+  - type: ShadowkinLight
   - type: PointLight
     radius: 10
     energy: 0.8
@@ -107,7 +108,6 @@
   components:
   - type: Sprite
     state: off
-  - type: ShadowkinLight
   - type: PointLight
     enabled: true
   - type: PoweredLight


### PR DESCRIPTION
# Media (woah!)

### Critical/Dead Shadowkin are returned from The Dark.

https://github.com/Simple-Station/Parkstation/assets/77995199/20a078ae-efeb-4718-9375-6d44cffca92e

### Critical Shadowkin will not gain power or activate any powers randomly.

https://github.com/Simple-Station/Parkstation/assets/77995199/809aa5fa-9952-437d-909a-5ab78be089d2

### Cuffed Shadowkin will not be able to use powers, random or otherwise.

https://github.com/Simple-Station/Parkstation/assets/77995199/9e829ca9-afa6-4b59-9f1c-723f1d970457

### Being a super tired Shadowkin won't make you sleep so hard that you wake up.

https://github.com/Simple-Station/Parkstation/assets/77995199/e428ea3b-9351-47cc-9e6e-73a8188f781f


# Changelog

:cl:
- fix: Critical/Dead Shadowkin are returned from The Dark.
- tweak: Critical Shadowkin will not gain power or activate any powers randomly.
- tweak: Cuffed Shadowkin will not be able to use powers, random or otherwise.
- tweak: More lights are affected by Shadowkin Darkening.
- fix: Shadowkin should no longer randomly lose the ability to use their powers.
- fix: Being a super tired Shadowkin won't make you sleep so hard that you wake up.
