### PR TITLE
Sate the Oversized Appetite of Welders 

### DIFF
--- a/Content.Server/Tools/Components/WelderComponent.cs
+++ b/Content.Server/Tools/Components/WelderComponent.cs
@@ -26,7 +26,7 @@ namespace Content.Server.Tools.Components
         ///     Fuel consumption per second, while the welder is active.
         /// </summary>
         [DataField("fuelConsumption"), ViewVariables(VVAccess.ReadWrite)]
-        public FixedPoint2 FuelConsumption { get; } = FixedPoint2.New(2.0f);
+        public FixedPoint2 FuelConsumption { get; } = FixedPoint2.New(0.1f);
 
         /// <summary>
         ///     A fuel amount to be consumed when the welder goes from being unlit to being lit.

--- a/Resources/Prototypes/SimpleStation14/Entities/Mobs/Player/silicon_base.yml
+++ b/Resources/Prototypes/SimpleStation14/Entities/Mobs/Player/silicon_base.yml
@@ -176,7 +176,7 @@
           visible: false
     - type: Repairable
       fuelcost: 60
-      doAfterDelay: 32
+      doAfterDelay: 18
     - type: Bloodstream
       damageBleedModifiers: BloodlossIPC
       bloodReagent: Water


### PR DESCRIPTION
# Description

"Reduces" the amount of fuel welders consume, it was `2/sec`, raised from `0.05/sec`, now it will be `0.1/sec`.

---

# Changelog

:cl:
- tweak: Welders use much less fuel idly
- tweak: IPCs take less time to repair
