### PR TITLE
Fix Rejoin Bug

### DIFF
--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -1605,8 +1605,8 @@ namespace Content.Shared.CCVar
         /// <summary>
         /// Time that players have to wait before rules can be accepted.
         /// </summary>
-        public static readonly CVarDef<float> RulesWaitTime =
-            CVarDef.Create("rules.time", 45f, CVar.SERVER | CVar.REPLICATED);
+        public static readonly CVarDef<int> RulesWaitTime = // Parkstation-FixRules // Causes game to not switch state, making gameplay not playable?
+            CVarDef.Create("rules.time", 45, CVar.SERVER | CVar.REPLICATED);
 
         /// <summary>
         /// Don't show rules to localhost/loopback interface.


### PR DESCRIPTION
# Description

Sets the rules time CCVar to an integer, which the client seemed to be expecting but it was a float, so joining caused an error with state changes that only ever caused a noticeable issue when you were playing in a round.

---

# Changelog

:cl:
- fix: Fixed rejoining the server causing most gameplay elements to not work
