### PR TITLE
Reinforced Reinforced Tiles

### DIFF
--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Utils.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Utils.cs
@@ -3,6 +3,7 @@ using Content.Server.Atmos.Components;
 using Content.Server.Cargo.Systems;
 using Content.Shared.Atmos;
 using Content.Shared.Atmos.Components;
+using Content.Shared.Maps;
 using Robust.Shared.Map.Components;
 using Dependency = Robust.Shared.IoC.DependencyAttribute;
 
@@ -111,7 +112,7 @@ public partial class AtmosphereSystem
     /// <param name="tile">The indices of the tile.</param>
     private void PryTile(MapGridComponent mapGrid, Vector2i tile)
     {
-        if (!mapGrid.TryGetTileRef(tile, out var tileRef))
+        if (!mapGrid.TryGetTileRef(tile, out var tileRef) || tileRef.Tile.GetContentTileDefinition().Reinforced) // Parkstation-ReinforcedReinforcedTiles
             return;
 
         _tile.PryTile(tileRef);

--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Utils.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Utils.cs
@@ -3,7 +3,7 @@ using Content.Server.Atmos.Components;
 using Content.Server.Cargo.Systems;
 using Content.Shared.Atmos;
 using Content.Shared.Atmos.Components;
-using Content.Shared.Maps;
+using Content.Shared.Maps; // Parkstation-ReinforcedReinforcedTiles
 using Robust.Shared.Map.Components;
 using Dependency = Robust.Shared.IoC.DependencyAttribute;
 

--- a/Content.Shared/Maps/ContentTileDefinition.cs
+++ b/Content.Shared/Maps/ContentTileDefinition.cs
@@ -59,6 +59,14 @@ namespace Content.Shared.Maps
 
         [DataField("friction")] public float Friction { get; set; } = 0.2f;
 
+        // Parkstation-ReinforcedReinforcedTiles-Start
+        /// <summary>
+        /// Whether this tile is reinforced or not.
+        /// This will affect, for instance, if it will be ripped up in atmospheric decompression.
+        /// </summary>
+        [DataField("reinforced")] public bool Reinforced { get; private set; } = false;
+        // Parkstation-ReinforcedReinforcedTiles-End
+
         [DataField("variants")] public byte Variants { get; set; } = 1;
 
         /// <summary>

--- a/Resources/Prototypes/Tiles/floors.yml
+++ b/Resources/Prototypes/Tiles/floors.yml
@@ -453,6 +453,7 @@
   baseTurf: Plating
   isSubfloor: false
   canCrowbar: true
+  reinforced: true
   footstepSounds:
     collection: FootstepHull
   itemDrop: FloorTileItemReinforced
@@ -770,6 +771,7 @@
   baseTurf: Plating
   isSubfloor: false
   canCrowbar: true
+  reinforced: true
   footstepSounds:
     collection: FootstepFloor
   itemDrop: FloorTileItemShuttleWhite
@@ -782,6 +784,7 @@
   baseTurf: Plating
   isSubfloor: false
   canCrowbar: true
+  reinforced: true
   footstepSounds:
     collection: FootstepFloor
   itemDrop: FloorTileItemShuttleBlue
@@ -806,6 +809,7 @@
   baseTurf: Plating
   isSubfloor: false
   canCrowbar: true
+  reinforced: true
   footstepSounds:
     collection: FootstepFloor
   itemDrop: FloorTileItemShuttlePurple
@@ -818,6 +822,7 @@
   baseTurf: Plating
   isSubfloor: false
   canCrowbar: true
+  reinforced: true
   footstepSounds:
     collection: FootstepFloor
   itemDrop: FloorTileItemShuttleRed
@@ -832,6 +837,7 @@
   baseTurf: Plating
   isSubfloor: false
   canCrowbar: true
+  reinforced: true
   footstepSounds:
     collection: FootstepTile
   itemDrop: FloorTileItemGold
@@ -844,6 +850,7 @@
   baseTurf: Plating
   isSubfloor: false
   canCrowbar: true
+  reinforced: true
   footstepSounds:
     collection: FootstepTile
   itemDrop: FloorTileItemSilver
@@ -858,6 +865,7 @@
   baseTurf: Plating
   isSubfloor: false
   canCrowbar: true
+  reinforced: true
   footstepSounds:
     collection: FootstepTile
   itemDrop: SheetGlass1
@@ -872,6 +880,7 @@
   baseTurf: Plating
   isSubfloor: false
   canCrowbar: true
+  reinforced: true
   footstepSounds:
     collection: FootstepTile
   itemDrop: SheetRGlass1


### PR DESCRIPTION
# Description

Tiles can now be marked as reinforced, and won't pry up when explosive decompression occurs.

---

# Tasks

- [x] it

---

# Changelog

<!-- You can add an author after the `:cl:` to change the name that appears in the changelog, ex: `:cl: Death`, it will default to your GitHub display name -->

:cl:
- tweak: Reinforced tiles (and other tough tiles) will no longer rip up when explosive decompression occurs.
