### PR TITLE
Charger Burning Alert Fix

### DIFF
--- a/Content.Server/SimpleStation14/Silicon/Charge/Systems/SiliconChargerSystem.cs
+++ b/Content.Server/SimpleStation14/Silicon/Charge/Systems/SiliconChargerSystem.cs
@@ -264,7 +264,7 @@ public sealed class SiliconChargerSystem : EntitySystem
         if (damageDealt != null && damageDealt.Total > 0 && chargerComp.WarningTime < _timing.CurTime)
         {
             var popupBurn = Loc.GetString(chargerComp.OverheatString);
-            _popup.PopupEntity(popupBurn, entity, PopupType.MediumCaution);
+            _popup.PopupEntity(popupBurn, entity, entity, PopupType.MediumCaution);
 
             chargerComp.WarningTime = TimeSpan.FromSeconds(_random.Next(3, 7)) + _timing.CurTime;
         }


### PR DESCRIPTION
Should fix the bug with the burning announcement being displayed to all players.

---

# Changelog

<!-- You can add an author after the `:cl:` to change the name that appears in the changelog, ex: `:cl: Death`, it will default to your GitHub display name -->

:cl:
- fix: The entire station is no longer informed when you're burning to death in a charging station
