### PR TITLE
The mop stat now displays correctly (and is less dumb)

### DIFF
--- a/Content.Server/Fluids/EntitySystems/AbsorbentSystem.cs
+++ b/Content.Server/Fluids/EntitySystems/AbsorbentSystem.cs
@@ -1,5 +1,6 @@
 using Content.Server.Chemistry.EntitySystems;
 using Content.Server.Popups;
+using Content.Server.SimpleStation14.EndOfRoundStats.MopUsed; // Parkstation-EndOfRoundStats
 using Content.Shared.Chemistry.Components;
 using Content.Shared.Chemistry.Reagent;
 using Content.Shared.FixedPoint;
@@ -212,6 +213,8 @@ public sealed class AbsorbentSystem : SharedAbsorbentSystem
         absorberSoln.RemoveReagent(PuddleSystem.EvaporationReagent, split.Volume);
         puddleSolution.AddReagent(PuddleSystem.EvaporationReagent, split.Volume);
         absorberSoln.AddSolution(split, _prototype);
+
+        RaiseLocalEvent(new MopUsedStatEvent(user, split.Volume)); // Parkstation-EndOfRoundStats
 
         _solutionSystem.UpdateChemicals(used, absorberSoln);
         _solutionSystem.UpdateChemicals(target, puddleSolution);

--- a/Content.Server/SimpleStation14/EndOfRoundStats/MopUsed/MopUsedStatEvent.cs
+++ b/Content.Server/SimpleStation14/EndOfRoundStats/MopUsed/MopUsedStatEvent.cs
@@ -4,14 +4,12 @@ namespace Content.Server.SimpleStation14.EndOfRoundStats.MopUsed;
 
 public sealed class MopUsedStatEvent : EntityEventArgs
 {
-    public String Mopper;
+    public EntityUid Mopper;
     public FixedPoint2 AmountMopped;
-    public String? Username;
 
-    public MopUsedStatEvent(String mopper, FixedPoint2 amountMopped, String? username)
+    public MopUsedStatEvent(EntityUid mopper, FixedPoint2 amountMopped)
     {
         Mopper = mopper;
         AmountMopped = amountMopped;
-        Username = username;
     }
 }

--- a/Content.Server/SimpleStation14/EndOfRoundStats/MopUsed/MopUsedStatSystem.cs
+++ b/Content.Server/SimpleStation14/EndOfRoundStats/MopUsed/MopUsedStatSystem.cs
@@ -1,5 +1,6 @@
 using System.Linq;
 using Content.Server.GameTicking;
+using Content.Server.Mind;
 using Content.Shared.FixedPoint;
 using Content.Shared.GameTicking;
 using Content.Shared.SimpleStation14.CCVar;
@@ -10,6 +11,7 @@ namespace Content.Server.SimpleStation14.EndOfRoundStats.MopUsed;
 public sealed class MopUsedStatSystem : EntitySystem
 {
     [Dependency] private readonly IConfigurationManager _config = default!;
+    [Dependency] private readonly MindSystem _mind = default!;
 
 
     Dictionary<MopperData, FixedPoint2> userMopStats = new();
@@ -37,10 +39,13 @@ public sealed class MopUsedStatSystem : EntitySystem
     {
         timesMopped++;
 
+        var name = MetaData(args.Mopper).EntityName;
+        var username = _mind.TryGetMind(args.Mopper, out var mind) && mind.Session != null ? mind.Session.Name : null;
+
         var mopperData = new MopperData
         {
-            Name = args.Mopper,
-            Username = args.Username
+            Name = name,
+            Username = username
         };
 
         if (userMopStats.ContainsKey(mopperData))

--- a/Resources/Locale/en-US/SimpleStation14/Content/RoundEndStats/mopUsedStats.ftl
+++ b/Resources/Locale/en-US/SimpleStation14/Content/RoundEndStats/mopUsedStats.ftl
@@ -2,7 +2,7 @@ eorstats-mop-amountmopped = A total of [color={$impressColor}]{$amountMopped}[/c
 
 eorstats-mop-topmopper-header = The top moppers were:
 
-eorstats-mop-topmopper-hasusername = [color={$impressColor}]{$place}. {$name} with {$amountMopped} units mopped![/color]
-eorstats-mop-topmopper-hasnousername = [color={$impressColor}]{$place}. {$username} as {$name} with {$amountMopped} units mopped![/color]
+eorstats-mop-topmopper-hasusername = [color={$impressColor}]{$place}. {$username} as {$name} with {$amountMopped} units mopped![/color]
+eorstats-mop-topmopper-hasnousername = [color={$impressColor}]{$place}. {$name} with {$amountMopped} units mopped![/color]
 
 eorstats-mop-noamountmopped = Not one puddle was mopped this round!


### PR DESCRIPTION
# Changelog

<!-- You can add an author after the `:cl:` to change the name that appears in the changelog, ex: `:cl: Death`, it will default to your GitHub display name -->

:cl:
- fix: Fixed mopping end of round stat.
