### PR TITLE
Fix Shadowkin Dark Visibility

### DIFF
--- a/Content.Server/SimpleStation14/Eye/EyeStartup.cs
+++ b/Content.Server/SimpleStation14/Eye/EyeStartup.cs
@@ -25,7 +25,7 @@ namespace Content.Server.SimpleStation14.Eye
             if (_entityManager.HasComponent<GhostComponent>(uid))
                 component.VisibilityMask |= (uint) VisibilityFlags.AIEye;
 
-            _shadowkinPowerSystem.SetCanSeeInvisibility(uid, _entityManager.HasComponent<GhostComponent>(uid));
+            _shadowkinPowerSystem.SetVisibility(uid, _entityManager.HasComponent<GhostComponent>(uid));
         }
     }
 }

--- a/Content.Server/SimpleStation14/Species/Shadowkin/Components/ShadowkinDarkSwapPowerComponent.cs
+++ b/Content.Server/SimpleStation14/Species/Shadowkin/Components/ShadowkinDarkSwapPowerComponent.cs
@@ -1,7 +1,19 @@
+using Content.Server.NPC.Components;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype.List;
+
 namespace Content.Server.SimpleStation14.Species.Shadowkin.Components;
 
 [RegisterComponent]
 public sealed class ShadowkinDarkSwapPowerComponent : Component
 {
+    /// <summary>
+    ///     Factions temporarily deleted from the entity while swapped
+    /// </summary>
+    public List<string> SuppressedFactions = new();
 
+    /// <summary>
+    ///     Factions temporarily added to the entity while swapped
+    /// </summary>
+    [DataField("factions", customTypeSerializer: typeof(PrototypeIdListSerializer<NpcFactionPrototype>))]
+    public List<string> AddedFactions = new() { "ShadowkinDarkFriendly" };
 }

--- a/Content.Shared/SimpleStation14/Species/Shadowkin/Components/ShadowkinDarkSwappedComponent.cs
+++ b/Content.Shared/SimpleStation14/Species/Shadowkin/Components/ShadowkinDarkSwappedComponent.cs
@@ -23,6 +23,7 @@ public sealed class ShadowkinDarkSwappedComponent : Component
     [DataField("darken"), ViewVariables(VVAccess.ReadWrite)]
     public bool Darken = true;
 
+
     /// <summary>
     ///     How far to dim nearby lights
     /// </summary>

--- a/Resources/Prototypes/SimpleStation14/factions.yml
+++ b/Resources/Prototypes/SimpleStation14/factions.yml
@@ -1,0 +1,9 @@
+- type: npcFaction
+  id: ShadowkinDarkHostile
+  hostile:
+    - ShadowkinDarkFriendly
+
+- type: npcFaction
+  id: ShadowkinDarkFriendly
+  hostile:
+    - ShadowkinDarkHostile


### PR DESCRIPTION
# Changelog
:cl:
- add: Normal NPCs can no longer see DarkSwapped Shadowkin
- fix: Fixed everyone being able to see DarkSwapped Shadowkin
