### PR TITLE
Fix whitelistadd Requiring a Server Restart

### DIFF
--- a/Content.Server/Whitelist/WhitelistCommands.cs
+++ b/Content.Server/Whitelist/WhitelistCommands.cs
@@ -45,7 +45,7 @@ public sealed class AddWhitelistCommand : IConsoleCommand
             if (player.TryGetPlayerDataByUsername(name, out var playerData) &&
                 player.TryGetSessionByUsername(name, out var session))
             {
-                playerData.ContentData()!.Whitelisted = false;
+                playerData.ContentData()!.Whitelisted = true;
                 playtime.SendWhitelistCached(session);
             }
 


### PR DESCRIPTION
# Changelog

:cl:
- fix: Newly whitelisted people no longer need to wait for the server to restart to do whitelist things
