### PR TITLE
Cargo Armory Parkifying

### DIFF
--- a/Resources/Prototypes/SimpleStation14/Catalog/Cargo/cargo_armory.yml
+++ b/Resources/Prototypes/SimpleStation14/Catalog/Cargo/cargo_armory.yml
@@ -1,0 +1,49 @@
+- type: cargoProduct
+  id: ArmoryPv3Pistol
+  icon:
+    sprite: SimpleStation14/Objects/Weapons/Guns/Pistols/pv3mini.rsi
+    state: icon
+  product: CratePV3Pistol
+  cost: 6000
+  category: Armory
+  group: market
+
+- type: cargoProduct
+  id: ArmoryPv3Smg
+  icon:
+    sprite: SimpleStation14/Objects/Weapons/Guns/SMGs/pv3compact.rsi
+    state: icon
+  product: CratePV3Smg
+  cost: 10000
+  category: Armory
+  group: market
+
+- type: cargoProduct
+  id: ArmoryK12Pistol
+  icon:
+    sprite: SimpleStation14/Objects/Weapons/Guns/Pistols/k12mini.rsi
+    state: icon
+  product: CrateK12Pistol
+  cost: 4000
+  category: Armory
+  group: market
+
+- type: cargoProduct
+  id: ArmoryK12Smg
+  icon:
+    sprite: SimpleStation14/Objects/Weapons/Guns/Smgs/k12compact.rsi
+    state: icon
+  product: CrateK12Smg
+  cost: 8000
+  category: Armory
+  group: market
+
+- type: cargoProduct
+  id: ArmoryMilitia
+  icon:
+    sprite: Nyanotrasen/Objects/Weapons/Guns/Snipers/grand_rifle.rsi
+    state: base
+  product: CrateMilitia
+  cost: 6000
+  category: Armory
+  group: market

--- a/Resources/Prototypes/SimpleStation14/Catalog/Cargo/cargo_engineering.yml
+++ b/Resources/Prototypes/SimpleStation14/Catalog/Cargo/cargo_engineering.yml
@@ -1,0 +1,9 @@
+- type: cargoProduct
+  id: EngineeringPortableGenerator
+  icon:
+    sprite: Structures/Power/power.rsi
+    state: generator
+  product: CrateEngineeringPortableGenerator
+  cost: 1000
+  category: Engineering
+  group: market

--- a/Resources/Prototypes/SimpleStation14/Catalog/Fills/Crates/armory.yml
+++ b/Resources/Prototypes/SimpleStation14/Catalog/Fills/Crates/armory.yml
@@ -2,7 +2,7 @@
   id: CratePV3Pistol
   parent: CrateWeaponSecure
   name: PV-3 Mini Crate
-  description: "A crate containing three PV-3 Mini energy Personal Defence Weapons"
+  description: "A crate containing three PV-3 Mini energy Personal Defense Weapons"
   components:
   - type: StorageFill
     contents:
@@ -26,7 +26,7 @@
   id: CrateK12Pistol
   parent: CrateWeaponSecure
   name: K12 Mini Crate
-  description: "A crate containing two K12 Mini Ballistic Personal Defence Weapons"
+  description: "A crate containing two K12 Mini Ballistic Personal Defense Weapons"
   components:
   - type: StorageFill
     contents:
@@ -53,7 +53,7 @@
       - id: MagazinePistolSubMachineGun
 
 - type: entity
-  id:   CrateMilitia
+  id: CrateMilitia
   parent: CrateWeaponSecure
   name: Militia Crate
   description: "A crate containing four Mark 1 rifles, four armor vests, four berets, and eight stripper clips of .30 rifle"

--- a/Resources/Prototypes/SimpleStation14/Catalog/Fills/Crates/armory.yml
+++ b/Resources/Prototypes/SimpleStation14/Catalog/Fills/Crates/armory.yml
@@ -1,0 +1,82 @@
+- type: entity
+  id: CratePV3Pistol
+  parent: CrateWeaponSecure
+  name: PV-3 Mini Crate
+  description: "A crate containing three PV-3 Mini energy Personal Defence Weapons"
+  components:
+  - type: StorageFill
+    contents:
+      - id: WeaponLaserPv3Mini
+      - id: WeaponLaserPv3Mini
+      - id: WeaponLaserPv3Mini
+
+- type: entity
+  id: CratePV3Smg
+  parent: CrateWeaponSecure
+  name: PV-3 Compact Crate
+  description: "A crate containing three PV-3 Compact Energy Assault Weapons"
+  components:
+  - type: StorageFill
+    contents:
+      - id: WeaponLaserPv3Compact
+      - id: WeaponLaserPv3Compact
+      - id: WeaponLaserPv3Compact
+
+- type: entity
+  id: CrateK12Pistol
+  parent: CrateWeaponSecure
+  name: K12 Mini Crate
+  description: "A crate containing two K12 Mini Ballistic Personal Defence Weapons"
+  components:
+  - type: StorageFill
+    contents:
+      - id: WeaponPistolK12Mini
+      - id: WeaponPistolK12Mini
+      - id: MagazinePistol
+      - id: MagazinePistol
+      - id: MagazinePistol
+      - id: MagazinePistol
+
+- type: entity
+  id: CrateK12Smg
+  parent: CrateWeaponSecure
+  name: K12 Compact Crate
+  description: "A crate containing two K12 Compact Ballistic Assault Weapons"
+  components:
+  - type: StorageFill
+    contents:
+      - id: WeaponSubMachineGunK12Compact
+      - id: WeaponSubMachineGunK12Compact
+      - id: MagazinePistolSubMachineGun
+      - id: MagazinePistolSubMachineGun
+      - id: MagazinePistolSubMachineGun
+      - id: MagazinePistolSubMachineGun
+
+- type: entity
+  id:   CrateMilitia
+  parent: CrateWeaponSecure
+  name: Militia Crate
+  description: "A crate containing four Mark 1 rifles, four armor vests, four berets, and eight stripper clips of .30 rifle"
+  components:
+  - type: StorageFill
+    contents:
+      - id: WeaponSniperGrand
+      - id: WeaponSniperGrand
+      - id: WeaponSniperGrand
+      - id: WeaponSniperGrand
+      - id: SpeedLoaderLightRifle
+      - id: SpeedLoaderLightRifle
+      - id: SpeedLoaderLightRifle
+      - id: SpeedLoaderLightRifle
+      - id: SpeedLoaderLightRifle
+      - id: SpeedLoaderLightRifle
+      - id: SpeedLoaderLightRifle
+      - id: SpeedLoaderLightRifle
+      - id: ClothingHeadHatBeret
+      - id: ClothingHeadHatBeret
+      - id: ClothingHeadHatBeret
+      - id: ClothingHeadHatBeret
+      - id: ClothingOuterArmorBasic
+      - id: ClothingOuterArmorBasic
+      - id: ClothingOuterArmorBasic
+      - id: ClothingOuterArmorBasic

--- a/Resources/Prototypes/SimpleStation14/Catalog/Fills/Crates/engines.yml
+++ b/Resources/Prototypes/SimpleStation14/Catalog/Fills/Crates/engines.yml
@@ -1,0 +1,9 @@
+- type: entity
+  id: CrateEngineeringPortableGenerator
+  parent: CrateEngineering
+  name: Portable Generator Crate
+  description: "A crate containing a portable generator"
+  components:
+  - type: StorageFill
+    contents:
+      - id: GeneratorBasic

--- a/Resources/Prototypes/SimpleStation14/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/SimpleStation14/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -2,7 +2,7 @@
   name: pv3 compact
   parent: BaseWeaponBattery
   id: WeaponLaserPv3Compact
-  description: Standard issue Nyanotrasen laser SMG. Pew! Pew pew! Now we're talkin' scifi!
+  description: Standard issue Nanotrasen laser SMG. Pew! Pew pew! Now we're talkin' scifi!
   components:
   - type: Item
     size: 28
@@ -39,7 +39,7 @@
   name: pv3 mini
   parent: BaseWeaponBatterySmall
   id: WeaponLaserPv3Mini
-  description: Standard issue Nyanotrasen laser sidearm. This thing can bullseye a two metre target, it's not impossible!
+  description: Standard issue Nanotrasen laser sidearm. This thing can bullseye a two metre target, it's not impossible!
   components:
   - type: Sprite
     sprite: SimpleStation14/Objects/Weapons/Guns/Pistols/pv3mini.rsi


### PR DESCRIPTION
I noticed there was no way to get more of these "NT standardized" weapons so I decided to add them to the Cargo catalog, alongside a way to outfit the crew in the event of a severe disaster.

Looking for advice on the pricing of the crates.

:cl:
- add: Added SimpleStation specific armory weapons to cargo.
- add: Added Militia crate to cargo.
- add: Added Portable generator crate to cargo.
